### PR TITLE
[BUG] Invoice file generation loop over adjustments

### DIFF
--- a/cronos_api.go
+++ b/cronos_api.go
@@ -679,7 +679,7 @@ func (a *App) InvoiceStateHandler(w http.ResponseWriter, r *http.Request) {
 		a.cronosApp.DB.Save(&entries)
 		var adjustments []cronos.Adjustment
 		a.cronosApp.DB.Where("invoice_id = ?", invoice.ID).Find(&adjustments)
-		for i, _ := range entries {
+		for i, _ := range adjustments {
 			if adjustments[i].State == cronos.AdjustmentStateApproved.String() {
 				adjustments[i].State = cronos.AdjustmentStateSent.String()
 			}


### PR DESCRIPTION
We typically need to iterate over the adjustments to sum them up when inserting into the PDF, however I was iterating over the entries list and then trying to access the adjustments at the same index. This caused an index out of range error. This has been resolved.