### PR TITLE
[feature] Drag over Calendar

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -461,6 +461,30 @@ var App = new Vue({
 
             $('#entry-modal').modal('show');
         },
+        showNewEntryModalPopulated(day, hour) {
+            this.isNew = true;
+            let defaultStart = new Date(day);
+            defaultStart.setHours(hour)
+            defaultStart.setMinutes(0,0,0);
+
+            defaultEnd = new Date(day);
+            defaultEnd.setHours(defaultStart.getHours() + 1, 0,0,0);
+            let blankEntry = {
+                billing_code_id : null,
+                entry_id: null,
+                notes: null,
+                start: null,
+                end: null,
+                start_vis : moment(defaultStart).format( 'yyyy-MM-DDTHH:mm'),
+                end_vis : moment(defaultEnd).format( 'yyyy-MM-DDTHH:mm'),
+                duration_hours: 1,
+                start_day_of_week: day,
+                start_hour: hour,
+            }
+            this.selectedEntry = blankEntry;
+
+            $('#entry-modal').modal('show');
+        },
         showEntryModal(entry) {
             console.log(this.selectedEntry)
             this.selectedEntry = entry;

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -57,6 +57,9 @@
         gtag('config', 'G-TRLQYPPXKE');
     </script>
     <style>
+        .highlight {
+          background-color: rgba(255, 255, 0, 0.56); /* or any other highlight color */
+        }
     </style>
     <script>
         // Parse JWT for persisted logins and check if we can route to the correct page
@@ -181,8 +184,8 @@
                     </td>
                 </tr>
                         <tr v-for="(hour, hourIndex) in hours" :key="hourIndex">
-                            <td>{{ hour.display }}</td>
-                            <td v-for="(day, dayIndex) in days" :key="dayIndex" class="hour-block" @click="showNewEntryModalPopulated(currentWeekDaysFormatted[dayIndex], hour.hour)">
+                            <td style="user-select: none">{{ hour.display }}</td>
+                            <td v-for="(day, dayIndex) in days" :key="dayIndex" :class="['hour-block']" @mousedown="startDrag(currentWeekDaysFormatted[dayIndex], hour.hour, $event)" @mouseover="onDragOver(currentWeekDaysFormatted[dayIndex], hour.hour, $event)" @mouseup="endDrag(currentWeekDaysFormatted[dayIndex], hour.hour, $event)" :data-day="currentWeekDays[dayIndex]" :data-hour="hour.hour" >
                                 <!-- You can use Vue.js data and methods to dynamically generate entries here -->
                                 <div v-for="entry in getEntries(day, hour.hour)" :key="entry.entry_id" :id="entry.entry_id"
                                      @click="showEntryModal(entry)"

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -182,7 +182,7 @@
                 </tr>
                         <tr v-for="(hour, hourIndex) in hours" :key="hourIndex">
                             <td>{{ hour.display }}</td>
-                            <td v-for="(day, dayIndex) in days" :key="dayIndex" class="hour-block">
+                            <td v-for="(day, dayIndex) in days" :key="dayIndex" class="hour-block" @click="showNewEntryModalPopulated(currentWeekDaysFormatted[dayIndex], hour.hour)">
                                 <!-- You can use Vue.js data and methods to dynamically generate entries here -->
                                 <div v-for="entry in getEntries(day, hour.hour)" :key="entry.entry_id" :id="entry.entry_id"
                                      @click="showEntryModal(entry)"


### PR DESCRIPTION
> This is a much needed feature update, and simply a quick iteration step as we continue to improve. This release will allow you to generate a new entry by simply clicking on the hour slot on the calendar.
> 
> This does not yet allow for drag and drop, nor does it highlight anything, and limits you to 1--hour blocks (that you can update after). But it marks a significant improvement over the "new entry" button.

Scratch that we got this bad boy working!

When you drag over it will highlight the hours and you can select multiple hours at once!