### PR TITLE
Log new contact in HubSpot on survey response

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
             CLOUD_SQL_DATABASE_NAME=${{ secrets.CLOUD_SQL_DATABASE_NAME }}
             GCP_PROJECT=${{ secrets.GCP_PROJECT }}
             GCS_BUCKET=${{ secrets.GCS_BUCKET }}
+            HUBSPOT_API_KEY=${{ secrets.HUBSPOT_API_KEY }}
             JWT_SECRET=${{ secrets.JWT_SECRET }}
             SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }}
             ENVIRONMENT=production

--- a/survey_api.go
+++ b/survey_api.go
@@ -89,7 +89,7 @@ func (a *App) hubSpotAPIRequest(method, url string, payload interface{}) (*http.
 	HubSpotAPIToken := os.Getenv("HUBSPOT_API_KEY")
 	if HubSpotAPIToken == "" {
 		log.Println("HubSpot API token not set")
-		return nil, fmt.Errorf("HubSpot API token not set")
+		return nil, errors.New("HubSpot API token not set")
 	}
 
 	// Convert the payload to JSON
@@ -138,7 +138,7 @@ func (a *App) createHubSpotContact(email, userRole string) (int, error) {
 	// Check for successful response
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		log.Printf("Failed to create HubSpot contact: Status %d", resp.StatusCode)
-		return 0, fmt.Errorf("failed to create contact in HubSpot")
+		return 0, errors.New("failed to create contact in HubSpot")
 	}
 
 	// Parse the response to get the Contact ID (VID)
@@ -194,7 +194,7 @@ func (a *App) createHubSpotNote(contactID int, messageText string) error {
 	// Check for successful response
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		log.Printf("Failed to create HubSpot note: Status %d", resp.StatusCode)
-		return fmt.Errorf("failed to create note in HubSpot")
+		return errors.New("failed to create note in HubSpot")
 	}
 
 	log.Printf("Note successfully created for HubSpot contact ID: %d", contactID)


### PR DESCRIPTION
Automatically create a new contact in HubSpot when a user submits a survey response.

Test results:

Console:

<img width="510" alt="image" src="https://github.com/user-attachments/assets/4722cb22-ad77-4cf1-80a7-efce5c632c9d">


Log after survey complete:

```
2024/10/14 21:39:18 Development/Snowpack/website/survey_api.go:230
[0.805ms] [rows:1] UPDATE `surveys` SET `created_at`=?,`updated_at`=?,`deleted_at`=?,`survey_type`=?,`user_email`=?,`user_role`=?,`company_name`=?,`completed`=? WHERE `surveys`.`deleted_at` IS NULL AND `id` = ?
2024/10/14 21:39:18 HubSpot contact created successfully
```


Record in HubSpot:

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/39dd5add-1ee0-468f-833b-6ef85ee4637c">