### PR TITLE
Only show Active Billing Codes on timesheet

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -17,6 +17,7 @@ var App = new Vue({
         staff : null,
         rates : null,
         billing_codes : null,
+        active_billing_codes: null,
         accounts : null,
         projects : null,
         draftInvoices : null,
@@ -639,6 +640,20 @@ var App = new Vue({
             .catch(error => {
                 console.log(error)
             })
+        },
+        fetchActiveBillingCodes(){
+            axios({
+                method: 'get',
+                url: '/api/active_billing_codes',
+                headers: {'Content-Type': 'application/json', 'x-access-token': window.localStorage.snowpack_token},
+            })
+                .then(response => {
+                    this.active_billing_codes = response.data
+                    console.log("retrieved active billing codes")
+                })
+                .catch(error => {
+                    console.log(error)
+                })
         },
         fetchAccounts(){
             axios({

--- a/cronos_api.go
+++ b/cronos_api.go
@@ -59,6 +59,16 @@ func (a *App) BillingCodesListHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(&billingCodes)
 }
 
+// ActiveBillingCodesListHandler provides a list of BillingCodes that are available and active for the
+// entry to be generated
+func (a *App) ActiveBillingCodesListHandler(w http.ResponseWriter, r *http.Request) {
+	var billingCodes []cronos.BillingCode
+	a.cronosApp.DB.Preload("Rate").Preload("InternalRate").Where("active_start <= ? and active_end >= ?", time.Now(), time.Now()).Find(&billingCodes)
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(&billingCodes)
+}
+
 // EntriesListHandler provides a list of Entries that are available
 func (a *App) EntriesListHandler(w http.ResponseWriter, r *http.Request) {
 	var entries []cronos.Entry

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func main() {
 	api.HandleFunc("/rates/{id:[0-9]+}", a.RateHandler).Methods("GET", "PUT", "POST", "DELETE")
 	api.HandleFunc("/billing_codes", a.BillingCodesListHandler).Methods("GET")
 	api.HandleFunc("/billing_codes/{id:[0-9]+}", a.BillingCodeHandler).Methods("GET", "PUT", "POST", "DELETE")
+	api.HandleFunc("/active_billing_codes", a.ActiveBillingCodesListHandler).Methods("GET")
 	api.HandleFunc("/adjustments/{id:[0-9]+}", a.AdjustmentHandler).Methods("GET", "PUT", "POST", "DELETE")
 	api.HandleFunc("/adjustments/state/{id:[0-9]+}/{state:(?:void)|(?:draft)|(?:approve)}", a.AdjustmentStateHandler).Methods("POST")
 	api.HandleFunc("/user/invoices", a.ClientInvoiceHandler).Methods("GET")

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -131,7 +131,7 @@
                             <div class="modal-body" style="">
                                 <label>Select Billing Code</label>
                                 <select v-model="selectedEntry.billing_code_id">
-                                    <option v-for="billing_code in billing_codes" :value="billing_code.ID">
+                                    <option v-for="billing_code in active_billing_codes" :value="billing_code.ID">
                                        {{billing_code.code}} : {{billing_code.name}}
                                     </option>
                                 </select>
@@ -726,6 +726,7 @@
     App.fetchStaff();
     App.fetchProjects();
     App.fetchBillingCodes();
+    App.fetchActiveBillingCodes();
     App.fetchEntries();
     App.updateEventSizes();
 </script>


### PR DESCRIPTION
I've been running into an annoying UI issue where we have too many billing codes that are showing up in the drop down when I try to create a timesheet entry. This is because both non-relevant billling codes, and inactive ones are showing. This is also leading to an increase in bugs where you can create timesheet entries for billing codes that are no longer inactive, leading to time falling off our timesheets.

This quick fix resolves that.