### PR TITLE
Add cache-busting script for stylesheet

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,12 @@ jobs:
       - run: git config --global url."https://${{ secrets.GH_ACCESS_TOKEN }}:x-oauth-basic@github.com/snowpackdata".insteadOf "https://github.com/snowpackdata"
       - name: Go Get
         run: go get .
+      # Recompile output.css for UI changes
+      - name: Generate Tailwind CSS
+        uses: ZoeyVid/tailwindcss-update@v1.4.0                  
       - name: Build
         run: go build -v ./...
-      # Generate the Git commit hash
+      # Create environment variable of current Git hash
       - name: Generate Commit Hash
         id: commit-hash
         run: echo "VERSION=$(git rev-parse --short HEAD)" >> $GIT_HASH

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,10 @@ jobs:
         run: go get .
       - name: Build
         run: go build -v ./...
+      # Generate the Git commit hash
+      - name: Generate Commit Hash
+        id: commit-hash
+        run: echo "VERSION=$(git rev-parse --short HEAD)" >> $GIT_HASH
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v1'
         with:
@@ -33,6 +37,7 @@ jobs:
         with:
           build_env_vars: |-
               GOPRIVATE=github.com/snowpackdata/cronos
+              GIT_HASH=${{ env.GIT_HASH }}
           env_vars: |-
             SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }}
             CLOUD_SQL_CONNECTION_NAME=${{ secrets.CLOUD_SQL_CONNECTION_NAME }}

--- a/assets/css/outputs.css
+++ b/assets/css/outputs.css
@@ -936,10 +936,6 @@ select {
   margin-top: -3rem;
 }
 
-.mb-2 {
-  margin-bottom: 0.5rem;
-}
-
 .mb-4 {
   margin-bottom: 1rem;
 }
@@ -992,15 +988,12 @@ select {
   margin-top: 2rem;
 }
 
-.mt-auto {
-  margin-top: auto;
+.mb-2 {
+  margin-bottom: 0.5rem;
 }
 
-.line-clamp-2 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+.mt-auto {
+  margin-top: auto;
 }
 
 .line-clamp-3 {
@@ -1008,6 +1001,13 @@ select {
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
+}
+
+.line-clamp-2 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .block {
@@ -1060,6 +1060,11 @@ select {
 
 .aspect-video {
   aspect-ratio: 16 / 9;
+}
+
+.size-10 {
+  width: 2.5rem;
+  height: 2.5rem;
 }
 
 .size-12 {
@@ -1116,10 +1121,6 @@ select {
   min-height: 100%;
 }
 
-.w-10 {
-  width: 2.5rem;
-}
-
 .w-52 {
   width: 13rem;
 }
@@ -1146,6 +1147,10 @@ select {
 
 .w-screen {
   width: 100vw;
+}
+
+.w-10 {
+  width: 2.5rem;
 }
 
 .max-w-2xl {
@@ -1180,16 +1185,16 @@ select {
   max-width: 20rem;
 }
 
-.flex-1 {
-  flex: 1 1 0%;
-}
-
 .flex-auto {
   flex: 1 1 auto;
 }
 
 .flex-none {
   flex: none;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
 }
 
 .shrink {
@@ -1789,6 +1794,11 @@ select {
   line-height: 1.75rem;
 }
 
+.text-lg\/6 {
+  font-size: 1.125rem;
+  line-height: 1.5rem;
+}
+
 .text-lg\/8 {
   font-size: 1.125rem;
   line-height: 2rem;
@@ -1949,6 +1959,10 @@ select {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.outline-2 {
+  outline-width: 2px;
+}
+
 .ring-1 {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
@@ -2000,6 +2014,14 @@ select {
 
 .transition-opacity {
   transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 type App struct {
 	cronosApp *cronos.App
 	logger    *log.Logger
-	gitHash   string
+	GitHash   string
 }
 
 func main() {
@@ -66,7 +66,7 @@ func main() {
 	a := &App{
 		cronosApp: &cronosApp,
 		logger:    log.New(os.Stdout, "http: ", log.LstdFlags),
-		gitHash:   gitHash,
+		GitHash:   gitHash,
 	}
 
 	// Mux is a subrouter generator that allows us to handle requests and route them to the appropriate handler
@@ -85,17 +85,17 @@ func main() {
 	api.Use(JwtVerify)
 
 	// our main routes are handled by the main router and are not protected by JWT
-	r.HandleFunc("/", indexHandler)
+	r.HandleFunc("/", a.indexHandler)
 	r.NotFoundHandler = http.HandlerFunc(notFoundHandler)
-	r.HandleFunc("/services", servicesHandler)
-	r.HandleFunc("/about", aboutHandler)
-	r.HandleFunc("/contact", contactHandler)
-	r.HandleFunc("/free-assessment", dataAssessmentHandler)
+	r.HandleFunc("/services", a.servicesHandler)
+	r.HandleFunc("/about", a.aboutHandler)
+	r.HandleFunc("/contact", a.contactHandler)
+	r.HandleFunc("/free-assessment", a.dataAssessmentHandler)
 	r.HandleFunc("/reports/examples/nba-report", exampleReportHandler)
-	r.HandleFunc("/blog", blogLandingHandler)
-	r.HandleFunc("/case-studies", caseStudyLandingHandler)
-	r.HandleFunc("/articles/{tag}", blogTagHandler)
-	r.HandleFunc("/blog/{slug}", blogHandler)
+	r.HandleFunc("/blog", a.blogLandingHandler)
+	r.HandleFunc("/case-studies", a.caseStudyLandingHandler)
+	r.HandleFunc("/articles/{tag}", a.blogTagHandler)
+	r.HandleFunc("/blog/{slug}", a.blogHandler)
 	r.HandleFunc("/contact-us-submit", a.ContactPageEmail).Methods("POST")
 
 	// Cronos Application pages, internal and external

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 type App struct {
 	cronosApp *cronos.App
 	logger    *log.Logger
+	gitHash   string
 }
 
 func main() {
@@ -30,6 +31,12 @@ func main() {
 	password := os.Getenv("CLOUD_SQL_PASSWORD")
 	dbHost := os.Getenv("CLOUD_SQL_CONNECTION_NAME")
 	databaseName := os.Getenv("CLOUD_SQL_DATABASE_NAME")
+	// Get the GIT_HASH value (default to "dev" if not set)
+	gitHash := os.Getenv("GIT_HASH")
+	if gitHash == "" {
+		gitHash = "dev"
+	}
+
 	socketPath := "/cloudsql/" + dbHost
 	cronosApp := cronos.App{}
 	dbURI := fmt.Sprintf("user=%s password=%s database=%s host=%s", user, password, databaseName, socketPath)
@@ -56,7 +63,11 @@ func main() {
 	}
 
 	// Add the cronos app to our webapp struct to access it across handlers
-	a := &App{cronosApp: &cronosApp, logger: log.New(os.Stdout, "http: ", log.LstdFlags)}
+	a := &App{
+		cronosApp: &cronosApp,
+		logger:    log.New(os.Stdout, "http: ", log.LstdFlags),
+		gitHash:   gitHash,
+	}
 
 	// Mux is a subrouter generator that allows us to handle requests and route them to the appropriate handler
 	// the router allows us to handle a couple high level subrouters and then specific routes.

--- a/templates/404.html
+++ b/templates/404.html
@@ -12,7 +12,7 @@
     <link rel="shortcut icon" type="icon" href="branding/favicon/favicon.ico">
 
     <!-- Tailwind CSS -->
-    <link href="/assets/css/outputs.css" rel="stylesheet" />
+    <link href="/assets/css/outputs.css?v={{ . }}" rel="stylesheet" />
 
     <!--  Montserrat font from Google Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />

--- a/templates/about.html
+++ b/templates/about.html
@@ -12,7 +12,7 @@
   <link rel="shortcut icon" type="icon" href="/branding/favicon/favicon.ico">
 
   <!-- Tailwind CSS -->
-  <link href="/assets/css/outputs.css" rel="stylesheet" />
+  <link href="/assets/css/outputs.css?v={{ . }}" rel="stylesheet" />
 
   <!--  Montserrat font from Google Fonts-->
   <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
@@ -360,4 +360,4 @@
 </footer>
 
 </html>
-<script src="/assets/js/index.js"></script>
+<script src="/assets/js/index.js?v={{ . }}"></script>

--- a/templates/blog_landing.gohtml
+++ b/templates/blog_landing.gohtml
@@ -18,7 +18,7 @@
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRLQYPPXKE"></script>
 <!-- Tailwind CSS -->
-<link href="/assets/css/outputs.css" rel="stylesheet" />
+<link href="/assets/css/outputs.css?v={{ .GitHash }}" rel="stylesheet" />
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -99,7 +99,7 @@
           <p class="mt-2 text-lg/8 text-gray-dark">Check out our case-studies, product deep dives, and write-ups on our existing work</p>
         </div>
         <div class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-        {{ range . }}
+        {{ range .Posts }}
           <article class="flex flex-col items-start justify-between h-full border-b-gray-light">
             <!-- Image Section -->
             <div class="relative w-full">
@@ -169,4 +169,4 @@
 </body>
 </html>
 
-<script src="/assets/js/index.js"></script>
+<script src="/assets/js/index.js?v={{ .GitHash }}"></script>

--- a/templates/blog_template.gohtml
+++ b/templates/blog_template.gohtml
@@ -7,9 +7,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 <meta name="description" content="Snowpack Data is an analytics consulting company based in California" />
 <meta name="author" content="Snowpack Data LLC" />
-<meta property="og:title" content="{{.Title}}">
-<meta property="og:description" content="{{.Subtitle}}">
-<meta property="og:image" content="https://snowpack-data.com/assets/img/{{.Splash}}">
+<meta property="og:title" content="{{ .Post.Title}}">
+<meta property="og:description" content="{{ .Post.Subtitle}}">
+<meta property="og:image" content="https://snowpack-data.com/assets/img/{{ .Post.Splash}}">
 <title>Snowpack Data</title>
 <!-- Favicon-->
 <!--Need a non relative link here due to the gohtml template being rendered in different locations-->
@@ -22,7 +22,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@200;300;400;800;900&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@200;300;400;800;900&family=Raleway:wght@200;300;400;700;800;900&display=swap" rel="stylesheet">
 
-<link type="text/css" rel="stylesheet" href="../assets/css/outputs.css">
+<link type="text/css" rel="stylesheet" href="/assets/css/outputs.css?v="{{ .GitHash }}>
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRLQYPPXKE"></script>
 <script>
@@ -108,15 +108,15 @@
 <main class="isolate bg-whitesmoke">
     <div class="container mx-auto sm:px-6 lg:px-8">
       <section class="page-section blog-page">
-        <h1 class="blog-title">{{.Title}}</h1>
+        <h1 class="blog-title">{{ .Post.Title}}</h1>
           <div class="container mx-auto sm:px-6 lg:px-8">
               <div class="text-center">
-                  <h2 class="blog-subtitle text-muted" style="margin-bottom: 1rem;">{{ .Subtitle }}</h2>
-                  <span class="text-gray-gray-dark blog-details">{{.Author}} | {{.Date}}</span>
+                  <h2 class="blog-subtitle text-muted" style="margin-bottom: 1rem;">{{ .Post.Subtitle }}</h2>
+                  <span class="text-gray-gray-dark blog-details">{{ .Post.Author}} | {{ .Post.Date}}</span>
               </div>
               <hr class="solid" style="margin-top:2vh;margin-bottom:4vh">
               <div class="blog-body">
-                {{ .RenderContent }}
+                {{ .Post.RenderContent }}
               </div>
           </div>
       </section>
@@ -152,5 +152,5 @@
 </body>
 </html>
 
-<script src="/assets/js/index.js"></script>
+<script src="/assets/js/index.js?v={{ .GitHash }}"></script>
 <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js?lang=css&lang=sql&lang=go"></script>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -12,7 +12,7 @@
     <link rel="shortcut icon" type="icon" href="/branding/favicon/favicon.ico">
 
     <!-- Tailwind CSS -->
-    <link href="/assets/css/outputs.css" rel="stylesheet" />
+    <link href="/assets/css/outputs.css?v={{ . }}" rel="stylesheet" />
 
     <!--  Montserrat font from Google Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
@@ -218,5 +218,5 @@
 </footer>
 </body>
 </html>
-<script src="/assets/js/index.js"></script>
-<script src="/assets/js/contact.js"></script>
+<script src="/assets/js/index.js?v={{ . }}"></script>
+<script src="/assets/js/contact.js?v={{ . }}"></script>

--- a/templates/data_assessment.html
+++ b/templates/data_assessment.html
@@ -22,10 +22,10 @@
 <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@200;300;400;800;900&family=Raleway:wght@200;300;400;700;800;900&display=swap" rel="stylesheet">
 
 <!-- Latest compiled and minified CSS -->
-<link rel="stylesheet" href="/assets/css/outputs.css">
+<link rel="stylesheet" href="/assets/css/outputs.css?v={{ . }}">
 
 <!-- Load javscript for survey -->
-<script src="assets/js/survey.js"></script> 
+<script src="assets/js/survey.js?v={{ . }}"></script>
 
 
 <!-- Google tag (gtag.js) -->
@@ -715,4 +715,4 @@ gtag('config', 'G-TRLQYPPXKE');
 
 </body>
 </html>
-<script src="/assets/js/index.js"></script>
+<script src="/assets/js/index.js?v={{ . }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRLQYPPXKE"></script>
 <!-- Tailwind CSS -->
-<link href="/assets/css/outputs.css" rel="stylesheet" />
+<link href="/assets/css/outputs.css?v={{ .GitHash }}" rel="stylesheet" />
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -183,7 +183,7 @@
       </p>
     </div>
     <div class="mx-auto mt-10 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-      {{ range . }}
+      {{ range .Posts }}
       <article class="flex h-full flex-col items-start justify-between">
         <!-- Image Section -->
         <div class="relative w-full">
@@ -260,4 +260,4 @@
 </body>
 </html>
 <!--Add Javascript-->
-<script src="/assets/js/index.js"></script>
+<script src="/assets/js/index.js?v={{ .GitHash }}"></script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,13 +12,11 @@
     <link rel="shortcut icon" type="icon" href="branding/favicon/favicon.ico">
 
     <!-- Tailwind CSS -->
-    <link href="/assets/css/outputs.css" rel="stylesheet" />
+    <link href="/assets/css/outputs.css?v={{ . }}" rel="stylesheet" />
 
     <!--  Montserrat font from Google Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
 
-    <!-- Login Functionality Files -->
-    <link href="../assets/js/login.js" rel="stylesheet" />
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRLQYPPXKE"></script>
@@ -83,7 +81,7 @@
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
 
 <!-- Template Main JS File -->
-<script src="/assets/js/login.js"></script>
+<script src="/assets/js/login.js?v={{ . }}"></script>
 <!-- Portfolio Modals-->
 
 </html>

--- a/templates/services.html
+++ b/templates/services.html
@@ -18,7 +18,7 @@
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRLQYPPXKE"></script>
     <!-- Tailwind CSS -->
-    <link href="/assets/css/outputs.css" rel="stylesheet" />
+    <link href="/assets/css/outputs.css?v={{ . }}" rel="stylesheet" />
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
@@ -244,5 +244,5 @@
 </body>
 </html>
 
-<script src="/assets/js/index.js"></script>
-<script src="/assets/js/services.js"></script>
+<script src="/assets/js/index.js?v={{ . }}"></script>
+<script src="/assets/js/services.js?v={{ . }}"></script>

--- a/views.go
+++ b/views.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 
@@ -88,7 +89,12 @@ func aboutHandler(w http.ResponseWriter, req *http.Request) {
 
 // Services page for all /services url requests
 func servicesHandler(w http.ResponseWriter, req *http.Request) {
-	http.ServeFile(w, req, "./templates/services.html")
+	var githash = os.Getenv("gitHash")
+	servicesTemplate, _ := template.ParseFiles("./templates/services.html")
+	err := servicesTemplate.Execute(w, githash)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 // Example report page for all /example_report url requests


### PR DESCRIPTION
Adds a cache-busting script to append a "version" to the query parameter that imports our stylesheet.

This ensures that the updated `outputs.css` file is loaded whenever a user opens a webpage.

Example when inspecting the rendered HTML in Chrome:

<img width="503" alt="image" src="https://github.com/user-attachments/assets/f3a48a76-2d7b-47c3-ab48-380b7e4070e5">
