### PR TITLE
Billing and Payroll Page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -12399,6 +12399,39 @@ background-color: #1a1e21; /*black*/
   height: 20px;
 }
 
+#billing-container {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: scroll;
+  height: 70vh;
+  margin: 20px;
+}
+
+#bill-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-style:normal;
+  font-size: 10pt;
+}
+
+#bill-table th, #bill-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+#bill-table td {
+  background-color: #f2f2f2;
+}
+#bill-table th {
+  background-color: var(--custom-blue-four);
+  color: white;
+}
+
+#bill-table tr {
+  height: 20px;
+}
+
 .link-dark {
   color: #1c399d;
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.1.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.0
-	github.com/snowpackdata/cronos v1.0.25
+	github.com/snowpackdata/cronos v1.0.26
 	golang.org/x/crypto v0.18.0
 	gorm.io/gorm v1.25.5
 )

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekuei
 github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
 github.com/sendgrid/sendgrid-go v3.13.0+incompatible h1:HZrzc06/QfBGesY9o3n1lvBrRONA+57rbDRKet7plos=
 github.com/sendgrid/sendgrid-go v3.13.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
-github.com/snowpackdata/cronos v1.0.25 h1:YWWlHTjOUOT1dq+CKPOne+8aCxboEysw+GsAmZp1GYM=
-github.com/snowpackdata/cronos v1.0.25/go.mod h1:2F0pMQNHsuETp0u6EyDVrR2xAM3886xbMktf+jJyUbY=
+github.com/snowpackdata/cronos v1.0.26 h1:SWMMM1QM6VPpYi9/5/ciKSObFsMTwpEUMovQfsvtSY0=
+github.com/snowpackdata/cronos v1.0.26/go.mod h1:2F0pMQNHsuETp0u6EyDVrR2xAM3886xbMktf+jJyUbY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/main.go
+++ b/main.go
@@ -132,6 +132,9 @@ func main() {
 	api.HandleFunc("/adjustments/{id:[0-9]+}", a.AdjustmentHandler).Methods("GET", "PUT", "POST", "DELETE")
 	api.HandleFunc("/adjustments/state/{id:[0-9]+}/{state:(?:void)|(?:draft)|(?:approve)}", a.AdjustmentStateHandler).Methods("POST")
 	api.HandleFunc("/user/invoices", a.ClientInvoiceHandler).Methods("GET")
+	api.HandleFunc("/bills", a.BillListHandler).Methods("GET")
+	api.HandleFunc("/bills/{id:[0-9]+}", a.BillHandler).Methods("GET")
+	api.HandleFunc("/bills/{id:[0-9]+}/{state:(?:paid)|(?:void)}", a.BillStateHandler).Methods("POST")
 
 	// Logging for web server
 	f, _ := os.Create("/var/log/golang/golang-server.log")

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -98,6 +98,7 @@
         <div @click="updateWorkingScreen('home')" class="tile"><i class="fa-solid fa-clock nav-icon"></i>Time Sheet</div>
         <div @click="updateWorkingScreen('admin')" class="tile"><i class="fa-solid fa-toolbox nav-icon"></i>Timesheet Admin</div>
         <div @click="updateWorkingScreen('invoices')" class="tile"><i class="fa-solid fa-file-invoice-dollar nav-icon"></i>Invoices</div>
+        <div @click="updateWorkingScreen('bills')" class="tile"><i class="fa-solid fa-file-invoice-dollar nav-icon"></i>Bills</div>
         <hr>
         <div @click="updateWorkingScreen('projects')" class="tile"><i class="fa-solid fa-bars-progress nav-icon"></i>Projects</div>
         <div @click="updateWorkingScreen('billing_codes')" class="tile"><i class="fa-solid fa-barcode nav-icon"></i>Billing Codes</div>
@@ -325,7 +326,7 @@
                 </div>
             </div>
         </div>
-        <!--        Invoicing & Billing UI SECTION-->
+        <!--        Invoicing UI SECTION-->
         <div id="billing" v-if="workingScreen.invoices" class="admin-content">
             <h2 class="blog-title">Invoicing</h2>
             <hr>
@@ -349,9 +350,9 @@
                         <td>{{ invoice.project.account.name }}</td>
                         <td>{{ invoice.name }}</td>
                         <td>Accepted {{ parseDate(invoice.sent_at, 'll') }}</td>
-                        <td>${{ invoice.total_fees }}</td>
-                        <td>${{ invoice.total_adjustments }}</button></td>
-                        <td>${{ invoice.total_amount }}</td>
+                        <td>{{ invoice.total_fees | currency }}</td>
+                        <td>{{ invoice.total_adjustments | currency }}</button></td>
+                        <td>{{ invoice.total_amount | currency }}</td>
                         <td>
                             <button @click="markInvoiceSent(invoice)" class="button-ready">Mark Sent</button>
                             <button @click="markInvoiceVoid(invoice)" class="button-void">Void</button>
@@ -365,9 +366,9 @@
                             {{ invoice.name }}
                         </td>
                         <td>Due {{ parseDate(invoice.due_at, 'll') }}</td>
-                        <td>${{ invoice.total_fees }}</td>
-                        <td>${{ invoice.total_adjustments }}</td>
-                        <td>${{ invoice.total_amount }}</td>
+                        <td>{{ invoice.total_fees | currency }}</td>
+                        <td>{{ invoice.total_adjustments | currency}}</td>
+                        <td>{{ invoice.total_amount | currency }}</td>
                         <td>
                             <button @click="markInvoicePaid(invoice)" class="button-ready">Mark Paid</button>
                             <button @click="markInvoiceVoid(invoice)" class="button-void">Void</button>
@@ -381,9 +382,54 @@
                             {{ invoice.name }}
                         </td>
                         <td>Paid {{ parseDate(invoice.closed_at, 'll') }}</td>
-                        <td>${{ invoice.total_fees }}</td>
-                        <td>${{ invoice.total_adjustments }}</td>
-                        <td>${{ invoice.total_amount }}</td>
+                        <td>{{ invoice.total_fees | currency }}</td>
+                        <td>{{ invoice.total_adjustments | currency }}</td>
+                        <td>{{ invoice.total_amount | currency }}</td>
+                        <td></td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <!--   Staff Billing UI SECTION-->
+        <div id="payroll" v-if="workingScreen.bills" class="admin-content">
+            <h2 class="blog-title">Payroll</h2>
+            <hr>
+            <div id="billing-container">
+                <!--                a table to hold all the invoices organized by state-->
+                <table id="bill-table">
+                    <thead>
+                    <tr>
+                        <th style="width:10%">Status</th>
+                        <th style="width:15%">Staff</th>
+                        <th style="width:20%">Name</th>
+                        <th style="width:10%">Hours</th>
+                        <th style="width:10%">Fee</th>
+                        <th style="width:10%">Action</th>
+                    </tr>
+                    </thead>
+                    <tr v-for="bill in filterBills()">
+                        <td><span style="color:#d97132;font-weight:bolder">Unpaid</span></td>
+                        <td>{{ bill.user.first_name + " " + bill.user.last_name }}</td>
+                       <td>
+                            <a :href="bill.file" download class="link-dark"><i class="fa-solid fa-download"></i></a>
+                            {{ bill.name }}
+                        </td>
+                        <td>{{ bill.total_hours | round }}</td>
+                        <td>{{ bill.total_fees/100 | currency }}</td>
+                        <td>
+                            <button @click="markBillPaid(bill)" class="button-ready">Mark Paid</button>
+                            <button @click="markBillVoid(bill)" class="button-void">Void</button>
+                        </td>
+                    </tr>
+                    <tr v-for="bill in filterBills(false)">
+                        <td><span style="color:forestgreen;font-weight:bolder">Paid</span></td>
+                        <td>{{ bill.user.first_name + " " + bill.user.last_name }}</td>
+                        <td>
+                            <a :href="bill.file" download class="link-dark"><i class="fa-solid fa-download"></i></a>
+                            {{ bill.name }}
+                        </td>
+                        <td>{{ bill.total_hours | round }}</td>
+                        <td>{{ bill.total_fees/100 | currency }}</td>
                         <td></td>
                     </tr>
                 </table>


### PR DESCRIPTION
Surface a UI that allows access to bills for staff payroll -- includes links to the actual Bill files and buttons to void or mark paid.

The other big change is that with the connection with the updated Cronos repo -- we now allow us to combine multiple paid invoices onto a single monthly staff payroll bill.

Under the hood I did a little bit of work on cleaning up the cash accounting, the `journals` table in our database while probably misnamed actually has a really clear transaction ledger for cash accounting which we can use for audits, I had totally forgotten that I coded this as a total throw


<img width="1914" alt="Screenshot 2025-01-03 at 10 24 15 AM" src="https://github.com/user-attachments/assets/439dd2f1-7aba-4ace-b7e3-fe2bd24fe010" />
away and didn't think too much about it.

